### PR TITLE
[Feature] Lines: add initial notes and module boilerplate

### DIFF
--- a/intersections/2d_lines.md
+++ b/intersections/2d_lines.md
@@ -1,0 +1,36 @@
+Lines in Two Dimensions
+=======================
+
+Two pieces of information define a line:
+  * Basepoint (say, `x0` [that 0 should really be subscript :(])
+  * Direction vector (say, `v`)
+So, for line `x(t)`, any given point can be found with `x + tv`. `x(t) = tx0` is called the "PARAMETERIZATION" of the line.
+
+e.g., `x(t) = [1, -2] + t[3,1]`:
+  * `x(0)` = `[1, -2]`
+  * `x(1) = [1, -2] + [3, 1] = [4, -1]`
+  * Note that `x(0)` does NOT represent val of `y` when `x` is 0: at that point, x is 1!
+^ In fact, a given line has *infinitely many* choices as basepoints! Any point can be the basepoint. Likewise, infinitely many direction vectors (distinct from unit vector).
+
+In contrast, "classic" line notation is `y = mx + b`, where `b` is the y-intercept, `m` is the slope, and `(0, b)` is the (single) basepoint. Now, in previous model, `m` can be captured by direction vector `[1, m]`: for every step 1 along `x`, move `m` along y. Limitation: can't represent a vertical line.
+
+More general equation: `Ax + By = k` (where `A` and `B` are not both equal to 0, though one can be). To get basepoint:
+  * If B != 0 => `(0, k/B)`
+  * If A != 0 => `(k/A, 0)`
+So, given `2x + 3y = 6`, basepoints can be either `(0, 2)` [`(0, 6/3)`] or `(3, 0)` [`(6/3, 0)`]. Direction vector is that which connects any two points on the line -- e.g., the two basepoints.
+
+From `Ax + By = k`, line is a set of points `(x, y)` such that `[A, B] dot_product [x, y] = k`. `[A, B]` is orthogonal to that line, and is called the "NORMAL VECTOR" of the line.
+
+#### Intersections in 2D
+
+Two lines in 2D are parallel if their normal vectors are parallel. (Seems tautological, but apparently doing it this way instead of using direction vectors is more extensible in higher dimensions.).
+
+If two lines are *not* parallel, they intersect; if they *are* parallel, they either don't intersect or intersect in infinitely many points (are the same line).
+
+How to check if two lines are the same line? Pick a point on each line, draw a vector connecting them, and check if it's orthogonal to the lines' normal vectors. If so, same line; if not, different parallel lines.
+
+#### Solving intersections
+
+Give the system of equations `Ax + By = k1` and `Cx + Dy = k2`, assuming that the lines are nonparallel, we can solve for x and y:
+  * `x = (Dk1 - Bk2) / (AD - BC)`
+  * `y = (-Ck1 + Ak2 / (AD - BC)`

--- a/intersections/intro.md
+++ b/intersections/intro.md
@@ -1,0 +1,14 @@
+Intersections
+=============
+
+Given a set of "flat" objects (lines, planes), what are their common points of intersection?
+
+"GEOMETRIC OBJECTS" are set of all points that satisfy a given equation (or other set of criteria). Flat objects satisfy a *linear* equation:
+  * Can add/subtract variables and constants
+  * Can multiply a variable x a constant
+  * So: no exponents, no multiplication * other variables
+In the real world, these equations generally come from observed relationships between different quantities. e.g.,
+  * Two weighted stocks (where 0 = none, 1 = 100%) must together add up to 1: `Wa + Wb = 1`
+  * To minimize risk, stocks must satisfy equation `2Wb - Wa = 0`
+  * Correct answer is where the two lines (geometric objects) intersect
+^ This is called a "SYSTEM OF EQUATIONS", and solving it is "SOLVING THE SYSTEM". A system of equations is indicated by multiple equations grouped under a left curly brace.

--- a/intersections/line.py
+++ b/intersections/line.py
@@ -1,0 +1,107 @@
+import sys
+from os import path
+from decimal import Decimal, getcontext
+
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+from vectors.vector import Vector  # nopep8
+
+getcontext().prec = 30  # After which we consider two numbers equal
+
+
+class Line(object):
+
+    NO_NONZERO_ELEMENTS_FOUND_MSG = "No nonzero elements found"
+
+    def __init__(self, normal_vector=None, constant_term=None):
+        self.dimension = 2
+
+        if not normal_vector:
+            all_zeros = ["0"] * self.dimension
+            normal_vector = Vector(all_zeros)
+        self.normal_vector = normal_vector
+
+        if not constant_term:
+            constant_term = Decimal("0")
+        self.constant_term = Decimal(constant_term)
+
+        self.set_basepoint()
+
+    def set_basepoint(self):
+        try:
+            n = self.normal_vector
+            c = self.constant_term
+            basepoint_coords = ["0"] * self.dimension
+
+            initial_index = Line.first_nonzero_index(n)
+            initial_coefficient = n[initial_index]
+
+            basepoint_coords[initial_index] = c / initial_coefficient
+            self.basepoint = Vector(basepoint_coords)
+
+        except Exception as e:
+            if str(e) == Line.NO_NONZERO_ELEMENTS_FOUND_MSG:
+                self.basepoint = None
+            else:
+                raise e
+
+    def __str__(self):
+
+        num_decimal_places = 3
+
+        def write_coefficient(coefficient, is_initial_term=False):
+            coefficient = round(coefficient, num_decimal_places)
+            if coefficient % 1 == 0:
+                coefficient = int(coefficient)
+
+            output = ""
+
+            if coefficient < 0:
+                output += "-"
+            if coefficient > 0 and not is_initial_term:
+                output += "+"
+
+            if not is_initial_term:
+                output += " "
+
+            if abs(coefficient) != 1:
+                output += "{}".format(abs(coefficient))
+
+            return output
+
+        n = self.normal_vector
+
+        try:
+            initial_index = Line.first_nonzero_index(self.normal_vector)
+            terms = [
+                write_coefficient(
+                    self.normal_vector[i],
+                    is_initial_term=(i == initial_index)
+                ) + "x_{}".format(i+1) for i in range(self.dimension)
+                if round(self.normal_vector[i], num_decimal_places) != 0
+            ]
+            output = " ".join(terms)
+
+        except Exception as e:
+            if str(e) == self.NO_NONZERO_ELEMENTS_FOUND_MSG:
+                output = "0"
+            else:
+                raise e
+
+        constant = round(self.constant_term, num_decimal_places)
+        if constant % 1 == 0:
+            constant = int(constant)
+        output += " = {}".format(constant)
+
+        return output
+
+    @staticmethod
+    def first_nonzero_index(iterable):
+        for k, item in enumerate(iterable):
+            if not MyDecimal(item).is_near_zero():
+                return k
+        raise Exception(Line.NO_NONZERO_ELEMENTS_FOUND_MSG)
+
+
+class MyDecimal(Decimal):
+    def is_near_zero(self, eps=1e-10):
+        return abs(self) < eps


### PR DESCRIPTION
This adds:
* A boilerplate `Line` module, downloaded from the class page (and tweaked to pass lint). TODO[[#9](https://github.com/david-davidson/linear-algebra/issues/9)]: unit tests for the boilerplate
* Notes on the intro material